### PR TITLE
Fixed 'Cannot convert undefined or null to object'

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,13 @@ class ServerlessPlugin {
 
   loadEnv() {
     try {
-      this.serverless.cli.log('DOTENV: Loading environment variables:');
       var config = this.serverless.service.custom && this.serverless.service.custom['dotenv'];
       var envPath = (config && config.path) || '.env';
       this.env = dotenvExpand(dotenv.config({path: envPath})).parsed;
+
+      if (!this.env) {
+        return;
+      }
 
       var include = false;
       if (config && config.include) {
@@ -38,6 +41,9 @@ class ServerlessPlugin {
             delete this.env[key]
           })
       }
+
+      this.serverless.cli.log('DOTENV: Loading environment variables:');
+
       Object.keys(this.env)
         .forEach((key) => {
           this.serverless.cli.log("\t - " + key);


### PR DESCRIPTION
In version 1.1.5

```
Serverless: DOTENV: Loading environment variables:

 Serverless Plugin Error --------------------------------------

  Cannot convert undefined or null to object
```

This is caused by #8 which means that it continues to try and run things like Object.keys on undefined

This PR restores the conditional check which returns if there's no env file.

I moved the log statement too because in the absence of a .env file it just said loading environment variables but then obviously nothing else.