### PR TITLE
Stop catching errors: crash early

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class ServerlessPlugin {
         this.serverless.service.provider.environment[key] = envVars[key]
       })
     } else {
-      throw new Error('DOTENV: Could not find .env file.')
+      throw new Error(`DOTENV: Could not find ${envFileName} file.`)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -14,19 +14,13 @@ class ServerlessPlugin {
     this.config =
       this.serverless.service.custom && this.serverless.service.custom['dotenv']
 
-    this.commands = {
-      deploy: {
-        lifecycleEvents: [
-          'package'
-        ]
-      },
-    }
     this.hooks = {
-      'before:package:initialize': this.beforeDeploy.bind(this)
+      'before:deploy:initialize': this.beforeInitialize.bind(this),
+      'before:deploy:function:initialize': this.beforeInitialize.bind(this),
     }
   }
 
-  beforeDeploy() {
+  beforeInitialize() {
     this.config =
       this.serverless.service.custom && this.serverless.service.custom['dotenv']
 
@@ -84,4 +78,5 @@ class ServerlessPlugin {
 }
 
 module.exports = ServerlessPlugin
+
 

--- a/index.js
+++ b/index.js
@@ -14,13 +14,19 @@ class ServerlessPlugin {
     this.config =
       this.serverless.service.custom && this.serverless.service.custom['dotenv']
 
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'package'
+        ]
+      },
+    }
     this.hooks = {
-      'before:deploy:initialize': this.beforeInitialize.bind(this),
-      'before:deploy:function:initialize': this.beforeInitialize.bind(this),
+      'before:package:initialize': this.beforeDeploy.bind(this)
     }
   }
 
-  beforeInitialize() {
+  beforeDeploy() {
     this.config =
       this.serverless.service.custom && this.serverless.service.custom['dotenv']
 
@@ -78,5 +84,4 @@ class ServerlessPlugin {
 }
 
 module.exports = ServerlessPlugin
-
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ class ServerlessPlugin {
       return options.env
     }
     
+    if (options.stage) {
+      return options.stage
+    }
+    
     if (process.env.NODE_ENV) {
       return process.env.NODE_ENV
     }

--- a/index.js
+++ b/index.js
@@ -7,30 +7,13 @@ const fs = require('fs')
 
 class ServerlessPlugin {
   constructor(serverless, options) {
-    this.options = options
     this.serverless = serverless
     this.serverless.service.provider.environment =
       this.serverless.service.provider.environment || {}
     this.config =
       this.serverless.service.custom && this.serverless.service.custom['dotenv']
 
-    this.commands = {
-      deploy: {
-        lifecycleEvents: [
-          'package'
-        ]
-      },
-    }
-    this.hooks = {
-      'before:package:initialize': this.beforeDeploy.bind(this)
-    }
-  }
-
-  beforeDeploy() {
-    this.config =
-      this.serverless.service.custom && this.serverless.service.custom['dotenv']
-
-    this.loadEnv(this.getEnvironment(this.options))
+    this.loadEnv(this.getEnvironment(options))
   }
 
   getEnvironment(options) {
@@ -78,10 +61,9 @@ class ServerlessPlugin {
         this.serverless.service.provider.environment[key] = envVars[key]
       })
     } else {
-      throw new Error(`DOTENV: Could not find ${envFileName} file.`)
+      throw new Error('DOTENV: Could not find .env file.')
     }
   }
 }
 
 module.exports = ServerlessPlugin
-

--- a/index.js
+++ b/index.js
@@ -7,13 +7,30 @@ const fs = require('fs')
 
 class ServerlessPlugin {
   constructor(serverless, options) {
+    this.options = options
     this.serverless = serverless
     this.serverless.service.provider.environment =
       this.serverless.service.provider.environment || {}
     this.config =
       this.serverless.service.custom && this.serverless.service.custom['dotenv']
 
-    this.loadEnv(this.getEnvironment(options))
+    this.commands = {
+      deploy: {
+        lifecycleEvents: [
+          'package'
+        ]
+      },
+    }
+    this.hooks = {
+      'before:package:initialize': this.beforeDeploy.bind(this)
+    }
+  }
+
+  beforeDeploy() {
+    this.config =
+      this.serverless.service.custom && this.serverless.service.custom['dotenv']
+
+    this.loadEnv(this.getEnvironment(this.options))
   }
 
   getEnvironment(options) {
@@ -61,9 +78,10 @@ class ServerlessPlugin {
         this.serverless.service.provider.environment[key] = envVars[key]
       })
     } else {
-      throw new Error('DOTENV: Could not find .env file.')
+      throw new Error(`DOTENV: Could not find ${envFileName} file.`)
     }
   }
 }
 
 module.exports = ServerlessPlugin
+

--- a/index.js
+++ b/index.js
@@ -38,39 +38,30 @@ class ServerlessPlugin {
 
   loadEnv(env) {
     var envFileName = this.resolveEnvFileName(env)
-    try {
-      let envVars = dotenvExpand(dotenv.config({ path: envFileName })).parsed
+    let envVars = dotenvExpand(dotenv.config({ path: envFileName })).parsed
 
-      var include = false
-      if (this.config && this.config.include) {
-        include = this.config.include
-      }
+    var include = false
+    if (this.config && this.config.include) {
+      include = this.config.include
+    }
 
-      if (envVars) {
-        this.serverless.cli.log(
-          'DOTENV: Loading environment variables from ' + envFileName + ':'
-        )
-        if (include) {
-          Object.keys(envVars)
-            .filter(key => !include.includes(key))
-            .forEach(key => {
-              delete envVars[key]
-            })
-        }
-        Object.keys(envVars).forEach(key => {
-          this.serverless.cli.log('\t - ' + key)
-          this.serverless.service.provider.environment[key] = envVars[key]
-        })
-      } else {
-        this.serverless.cli.log('DOTENV: Could not find .env file.')
-      }
-    } catch (e) {
-      console.error(
-        chalk.red(
-          '\n Serverless Plugin Error --------------------------------------\n'
-        )
+    if (envVars) {
+      this.serverless.cli.log(
+        'DOTENV: Loading environment variables from ' + envFileName + ':'
       )
-      console.error(chalk.red('  ' + e.message))
+      if (include) {
+        Object.keys(envVars)
+          .filter(key => !include.includes(key))
+          .forEach(key => {
+            delete envVars[key]
+          })
+      }
+      Object.keys(envVars).forEach(key => {
+        this.serverless.cli.log('\t - ' + key)
+        this.serverless.service.provider.environment[key] = envVars[key]
+      })
+    } else {
+      throw new Error('DOTENV: Could not find .env file.')
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -17,12 +17,12 @@ class ServerlessPlugin {
   }
 
   getEnvironment(options) {
-    if (process.env.NODE_ENV) {
-      return process.env.NODE_ENV
-    }
-
     if (options.env) {
       return options.env
+    }
+    
+    if (process.env.NODE_ENV) {
+      return process.env.NODE_ENV
     }
 
     return 'development'


### PR DESCRIPTION
Catching errors will allow broken deploys to continue rather silently.
This update removes the catching of errors and instead adds the
_throwing_ of an error when the .env file is not found.
There's no good reason to continue the deploy when you know the
environment variables can't be loaded.

If the file is not there and shouldn't be there, there's no reason to
use this plugin.

Additionally, this refactors the parsing of configuration to allow variables to be resolved.