### PR TITLE
Added exclude option to custom config; updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The plugin will look for your .env file in the same folder where you run the com
 
 > include: ...
 
-All env vars found in your file will be injected into your lambda functions. If you do not want all of them to be injected into your lambda functions, you can whitelist them with the `include` option. (Note that there is currently no "blacklist" option)
+All env vars found in your file will be injected into your lambda functions. If you do not want all of them to be injected into your lambda functions, you can whitelist them with the `include` option.
 
 Complete example:
 
@@ -66,6 +66,19 @@ custom:
     include:
       - AUTH0_CLIENT_ID
       - AUTH0_CLIENT_SECRET
+```
+
+> exclude: ...
+
+If you do not want all of them to be injected into your lambda functions, you can blacklist the unnecessary ones them with the `exclude` option.
+
+Example:
+
+```
+custom:
+  dotenv:
+    exclude:
+      - NODE_ENV # E.g for Google Cloud Functions, you cannot pass this env variable.
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ custom:
 
 > exclude: ...
 
-If you do not want all of them to be injected into your lambda functions, you can blacklist the unnecessary ones them with the `exclude` option.
+If you do not want all of them to be injected into your lambda functions, you can blacklist the unnecessary ones with the `exclude` option.
 
 Example:
 

--- a/index.js
+++ b/index.js
@@ -42,8 +42,14 @@ class ServerlessPlugin {
       let envVars = dotenvExpand(dotenv.config({ path: envFileName })).parsed
 
       var include = false
+      var exclude = false
+
       if (this.config && this.config.include) {
         include = this.config.include
+      }
+
+      if (this.config && this.config.exclude && !include) { // Don't allow both include and exclude to be specified
+        exclude = this.config.exclude
       }
 
       if (envVars) {
@@ -57,6 +63,13 @@ class ServerlessPlugin {
               delete envVars[key]
             })
         }
+        if (exclude) {
+          Object.keys(envVars)
+            .filter(key => exclude.includes(key))
+            .forEach(key => {
+              delete envVars[key]
+            })
+        }        
         Object.keys(envVars).forEach(key => {
           this.serverless.cli.log('\t - ' + key)
           this.serverless.service.provider.environment[key] = envVars[key]


### PR DESCRIPTION
Added an extra property for configuring a blacklist (environment properties to remove from the configuration). Useful in the context of Google Cloud Functions where `NODE_ENV` is not an allowable environment variable