### PR TITLE
Avoid overriding env variables with values defined in the system

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const dotenv = require('dotenv')
-const dotenvExpand = require('dotenv-expand')
 const chalk = require('chalk')
 const fs = require('fs')
 
@@ -45,7 +44,7 @@ class ServerlessPlugin {
   loadEnv(env) {
     var envFileName = this.resolveEnvFileName(env)
     try {
-      let envVars = dotenvExpand(dotenv.config({ path: envFileName })).parsed
+      let envVars = dotenv.config({ path: envFileName }).parsed
 
       var include = false
       if (this.config && this.config.include) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dotenv-plugin",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,11 +39,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
-    "dotenv-expand": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
-      "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/colynb/serverless-dotenv-plugin#readme",
   "dependencies": {
     "chalk": "^2.1.0",
-    "dotenv": "^4.0.0",
-    "dotenv-expand": "^4.0.1"
+    "dotenv": "^4.0.0"
   }
 }


### PR DESCRIPTION
When using `dotenv-expand`, if any of the environment variables specified in your .env file is already defined in your system, it uses that value instead of the one defined in the file.

With this change, we remove `dotenv-expand` from the project and use `dotenv` directly, in order to make sure that the environment variables are always read from the specified file