### PR TITLE
fix: correct file existence check.

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ class ServerlessPlugin {
         exclude = this.config.exclude
       }
 
-      if (envVars) {
+      if (envFileNames.length > 0) {
         if (this.logging) {
           this.serverless.cli.log(
             'DOTENV: Loading environment variables from ' +


### PR DESCRIPTION
This change is backwards compatible.

Quality notes:
* Functional:
  * Confirmed that before this change, when no dotenv file is found, the logged message is `Serverless: DOTENV: Loading environment variables from :`
  * Confirmed that after this change, when no dotenv file is found, the logged message is `Serverless: DOTENV: Could not find .env file.`