### PR TITLE
feat: add config that causes Serverless to halt if no .env file is found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,18 @@ custom:
       - AUTH0_CLIENT_SECRET
 ```
 
-> required: true|false (default false)
+> required.file: true|false (default false)
 
 By default, this plugin will exit gracefully and allow Serverless to continue even if it couldn't find a .env file to use. Set this to `true` to cause Serverless to halt if it could not find a .env file to use.
+
+Complete example:
+
+```yaml
+custom:
+  dotenv:
+    required:
+      file: true
+```
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ custom:
       - AUTH0_CLIENT_SECRET
 ```
 
+> required: true|false (default false)
+
+By default, this plugin will exit gracefully and allow Serverless to continue even if it couldn't find a .env file to use. Set this to `true` to cause Serverless to halt if it could not find a .env file to use.
+
 ### Usage
 
 Once loaded, you can now access the vars using the standard method for accessing ENV vars in serverless:

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const chalk = require('chalk')
 const fs = require('fs')
 
 const errorTypes = {
-  FILE_NOT_FOUND: 'FILE_NOT_FOUND'
+  HALT: 'HALT'
 };
 
 class ServerlessPlugin {
@@ -123,13 +123,13 @@ class ServerlessPlugin {
         const errorMsg = 'DOTENV: Could not find .env file.';
 
         if(this.fileRequired === true) {
-          throw Object.assign(new Error(errorMsg), { type: errorTypes.FILE_NOT_FOUND });
+          throw Object.assign(new Error(errorMsg), { type: errorTypes.HALT });
         } else if (this.logging) {
           this.serverless.cli.log('DOTENV: Could not find .env file.')
         }
       }
     } catch (e) {
-      if(this.fileRequired && e.type === errorTypes.FILE_NOT_FOUND) {
+      if(this.fileRequired && e.type === errorTypes.HALT) {
         throw e;
       }
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ const dotenvExpand = require('dotenv-expand')
 const chalk = require('chalk')
 const fs = require('fs')
 
+const errorTypes = {
+  FILE_NOT_FOUND: 'FILE_NOT_FOUND'
+};
+
 class ServerlessPlugin {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -16,6 +20,7 @@ class ServerlessPlugin {
       this.config && typeof this.config.logging !== 'undefined'
         ? this.config.logging
         : true
+    this.fileRequired = this.config && this.config.required;
 
     this.loadEnv(this.getEnvironment(options))
   }
@@ -115,11 +120,19 @@ class ServerlessPlugin {
           this.serverless.service.provider.environment[key] = envVars[key]
         })
       } else {
-        if (this.logging) {
+        const errorMsg = 'DOTENV: Could not find .env file.';
+
+        if(this.fileRequired === true) {
+          throw Object.assign(new Error(errorMsg), { type: errorTypes.FILE_NOT_FOUND });
+        } else if (this.logging) {
           this.serverless.cli.log('DOTENV: Could not find .env file.')
         }
       }
     } catch (e) {
+      if(this.fileRequired && e.type === errorTypes.FILE_NOT_FOUND) {
+        throw e;
+      }
+
       console.error(
         chalk.red(
           '\n Serverless Plugin Error --------------------------------------\n',

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ class ServerlessPlugin {
       this.config && typeof this.config.logging !== 'undefined'
         ? this.config.logging
         : true
-    this.fileRequired = this.config && this.config.required;
+    this.required = (this.config && this.config.required) || {};
 
     this.loadEnv(this.getEnvironment(options))
   }
@@ -122,14 +122,14 @@ class ServerlessPlugin {
       } else {
         const errorMsg = 'DOTENV: Could not find .env file.';
 
-        if(this.fileRequired === true) {
+        if(this.required.file === true) {
           throw Object.assign(new Error(errorMsg), { type: errorTypes.HALT });
         } else if (this.logging) {
           this.serverless.cli.log('DOTENV: Could not find .env file.')
         }
       }
     } catch (e) {
-      if(this.fileRequired && e.type === errorTypes.HALT) {
+      if(e.type === errorTypes.HALT) {
         throw e;
       }
 


### PR DESCRIPTION
This change is very similar to https://github.com/colynb/serverless-dotenv-plugin/pull/34, but it was old enough that resolving the merge conflict was difficult, so I went with a new PR. This version of the change is backwards compatible and does not change default behaviour.

This change requires https://github.com/colynb/serverless-dotenv-plugin/pull/66 to work properly. The quality notes below were done with both changes.

Quality notes:
* Functional:
  * Confirmed that if `.env` file is not found and `custom.dotenv` / `custom.dotenv.require` / `custom.dotenv.require.file` is not set, Serverless continues without issues
  * Confirmed that if `.env` file is not found and `custom.dotenv.require.file` is set to `false`, Serverless continues without issues
  * Confirmed that if `.env` file is not found and `custom.dotenv.require.file` is set to `true`, Serverless halts

---

`custom.dotenv.require.file` not set:
```
Serverless: Load command upgrade
Serverless: Load command uninstall
Serverless: DOTENV: Could not find .env file.
```

`custom.dotenv.require.file` set to `true`:
```
Serverless: Load command upgrade
Serverless: Load command uninstall
 
  Error --------------------------------------------------

  Error: DOTENV: Could not find .env file.
```