### PR TITLE
ci: init.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn install --frozen-lockfile
+      - run: yarn test


### PR DESCRIPTION
Depends on #70 

I noticed CI wasn't set up for this repository as I was adding unit tests in #70. Would you be interested in using GitHub Actions?