### PR TITLE
chore: add editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.*]
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Mostly a quality of life addition. This will tell editors to automatically use two spaces for indents to conform with the [prettier](https://github.com/colynb/serverless-dotenv-plugin/blob/master/.prettierrc) among other minor things.