### PR TITLE
test: adding tests for loadEnv().

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -179,5 +179,83 @@ describe('ServerlessPlugin', function () {
         expectedEnvVars,
       )
     })
+
+    it('removes keys not in config.include', function () {
+      const fileName = '.env'
+      const envVars = {
+        env1: 'env1value',
+        env2: 'env2value',
+        env3: 'env3value',
+      }
+      this.serverless.service.custom.dotenv.include = ['env2']
+
+      this.resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns(envVars)
+
+      this.requireStubs['dotenv-expand']
+        .withArgs(envVars)
+        .returns({ parsed: envVars })
+
+      this.plugin.loadEnv(this.env)
+
+      this.serverless.service.provider.environment.should.deep.equal({
+        env2: envVars.env2,
+      })
+    })
+
+    it('removes keys in config.exclude', function () {
+      const fileName = '.env'
+      const envVars = {
+        env1: 'env1value',
+        env2: 'env2value',
+        env3: 'env3value',
+      }
+      this.serverless.service.custom.dotenv.exclude = ['env2']
+
+      this.resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns(envVars)
+
+      this.requireStubs['dotenv-expand']
+        .withArgs(envVars)
+        .returns({ parsed: envVars })
+
+      this.plugin.loadEnv(this.env)
+
+      this.serverless.service.provider.environment.should.deep.equal({
+        env1: envVars.env1,
+        env3: envVars.env3,
+      })
+    })
+
+    it('ignores config.exclude if config.include is set', function () {
+      const fileName = '.env'
+      const envVars = {
+        env1: 'env1value',
+        env2: 'env2value',
+        env3: 'env3value',
+      }
+      this.serverless.service.custom.dotenv.include = ['env1', 'env2']
+      this.serverless.service.custom.dotenv.exclude = ['env2']
+
+      this.resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns(envVars)
+
+      this.requireStubs['dotenv-expand']
+        .withArgs(envVars)
+        .returns({ parsed: envVars })
+
+      this.plugin.loadEnv(this.env)
+
+      this.serverless.service.provider.environment.should.deep.equal({
+        env1: envVars.env1,
+        env2: envVars.env2,
+      })
+    })
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,9 @@ describe('ServerlessPlugin', function () {
       },
       service: {
         custom: {
-          dotenv: {},
+          dotenv: {
+            required: {},
+          },
         },
         provider: {},
       },
@@ -73,5 +75,30 @@ describe('ServerlessPlugin', function () {
 
   describe('resolveEnvFileNames()', function () {})
 
-  describe('loadEnv()', function () {})
+  describe('loadEnv()', function () {
+    beforeEach(function () {
+      this.env = 'unittests'
+      this.resolveEnvFileNames = this.sandbox.stub(
+        this.plugin,
+        'resolveEnvFileNames',
+      )
+    })
+
+    it('logs an error if no .env files are required and none are found', function () {
+      this.resolveEnvFileNames.withArgs(this.env).returns([])
+
+      this.plugin.loadEnv(this.env)
+
+      this.serverless.cli.log.should.have.been.calledWith(
+        'DOTENV: Could not find .env file.',
+      )
+    })
+
+    it('throws an error if no .env files are required but at least one is required', function () {
+      this.serverless.service.custom.dotenv.required.file = true
+      this.resolveEnvFileNames.withArgs(this.env).returns([])
+
+      should.Throw(() => this.plugin.loadEnv(this.env))
+    })
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -161,10 +161,10 @@ describe('ServerlessPlugin', function () {
       files.forEach((fileName) => {
         this.requireStubs.dotenv.config
           .withArgs({ path: fileName })
-          .returns(filesAndEnvVars[fileName])
+          .returns({ parsed: filesAndEnvVars[fileName] })
 
         this.requireStubs['dotenv-expand']
-          .withArgs(filesAndEnvVars[fileName])
+          .withArgs({ parsed: filesAndEnvVars[fileName] })
           .returns({ parsed: filesAndEnvVars[fileName] })
       })
 
@@ -192,10 +192,10 @@ describe('ServerlessPlugin', function () {
       this.resolveEnvFileNames.withArgs(this.env).returns([fileName])
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns(envVars)
+        .returns({ parsed: envVars })
 
       this.requireStubs['dotenv-expand']
-        .withArgs(envVars)
+        .withArgs({ parsed: envVars })
         .returns({ parsed: envVars })
 
       this.plugin.loadEnv(this.env)
@@ -217,10 +217,10 @@ describe('ServerlessPlugin', function () {
       this.resolveEnvFileNames.withArgs(this.env).returns([fileName])
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns(envVars)
+        .returns({ parsed: envVars })
 
       this.requireStubs['dotenv-expand']
-        .withArgs(envVars)
+        .withArgs({ parsed: envVars })
         .returns({ parsed: envVars })
 
       this.plugin.loadEnv(this.env)
@@ -244,10 +244,10 @@ describe('ServerlessPlugin', function () {
       this.resolveEnvFileNames.withArgs(this.env).returns([fileName])
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns(envVars)
+        .returns({ parsed: envVars })
 
       this.requireStubs['dotenv-expand']
-        .withArgs(envVars)
+        .withArgs({ parsed: envVars })
         .returns({ parsed: envVars })
 
       this.plugin.loadEnv(this.env)


### PR DESCRIPTION
~Adding corresponding unit tests for functionality introduced in #67.~

~I plan to add tests to cover the rest of `loadEnv()` if that's okay, although I won't have time to do so for the next little while. I thought these were valuable enough to merge on their own though.~

This should cover most of the `loadEnv()` functionality, except for the `logging` config. That one is a bit harder to tackle, so I'm hoping to get these in first.