### PR TITLE
feat: now runs on pull requests from forks.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  - pull_request
+  - push
 
 jobs:
   build:


### PR DESCRIPTION
Sorry looks like the `pull_request` action is required for CI to run on pull requests from forks as well.