### PR TITLE
feat: GitHub Action for publishing a new version.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release new version
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: Type of release based om semver (e.g. patch, minor, major)
+        required: true
+        default: minor
+
+jobs:
+  release:
+    name: Release new version to NPM
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          always-auth: true
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org
+      - name: Setup Git
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - run: yarn version --${{github.event.inputs.release-type}}
+      - name: Push commit and tag
+        run: |
+          git push
+          git push --follow-tags
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Not sure if this is something that interests you @colynb, but I was playing around with GitHub Actions and came up with one that can  publish a new version of this library via the GitHub UI:

![Screenshot of using GitHub Actions `workflow_dispatch` to create a new release](https://user-images.githubusercontent.com/8854618/103447371-865ce500-4c58-11eb-926f-e36329d4dd45.png)

([example run on another library](https://github.com/neverendingqs-sandbox/nodejs-lib-example/runs/1634858856?check_suite_focus=true))

If this interests you, aside from merging this pull request, you will also need to [create an encrypted secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) named `NODE_AUTH_TOKEN` with the value of an [npm access token](https://docs.npmjs.com/creating-and-viewing-access-tokens) to use it.