### PR TITLE
chore: remove open collective entry.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: serverless-dotenv-plugin
+open_collective: # serverless-dotenv-plugin
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry


### PR DESCRIPTION
The open collective link (https://opencollective.com/serverless-dotenv-plugin) is broken. I'm thinking of removing it from this file and the repo page unless you have concerns @colynb.