### PR TITLE
feat: adding variableExpansion option to turn off variable expansion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changes not included in this log but can be reviewed on GitHub:
 
 ## Unreleased
 
+## 3.3.0
+
+* feat: adding variableExpansion option to turn off variable expansion. ([#116](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/116))
+
 ## 3.2.0
 
 * refactor: use helper functions to help with readabilty and future changes. ([#112](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/112))

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ custom:
     required:
       # default: false
       file: true
+
+    # default: true
+    variableExpansion: false
 ```
 
 * path (string)
@@ -137,6 +140,12 @@ custom:
 * required.file: true|false (default false)
   * By default, this plugin will exit gracefully and allow Serverless to continue even if it couldn't find a .env file to use.
   * Set this to `true` to cause Serverless to halt if it could not find a .env file to use.
+
+* variableExpansion: true|false (default true)
+  * By default, variables can reference other variables
+    * E.g. `INNER_ENV=innerenv, OUTER_ENV=hi-$INNER_ENV`, would resolve to `INNER_ENV=innerenv, OUTER_ENV=hi-innerenv`
+  * Setting this to `false` will disable this feature
+    * E.g. `INNER_ENV=innerenv, OUTER_ENV=hi-$INNER_ENV`, would resolve to `INNER_ENV=innerenv, OUTER_ENV=hi-$INNER_ENV`
 
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ class ServerlessPlugin {
         ? this.config.logging
         : true
     this.required = (this.config && this.config.required) || {}
+    this.variableExpansion = !(
+      (this.config && this.config.variableExpansion) === false
+    )
 
     this.loadEnv(this.getEnvironment(options))
   }
@@ -75,9 +78,12 @@ class ServerlessPlugin {
    * @returns {Object}
    */
   parseEnvFiles(envFileNames) {
-    const envVarsArray = envFileNames.map(
-      (fileName) => dotenvExpand(dotenv.config({ path: fileName })).parsed,
-    )
+    const envVarsArray = envFileNames.map((fileName) => {
+      const parsed = dotenv.config({ path: fileName })
+      return this.variableExpansion
+        ? dotenvExpand(parsed).parsed
+        : parsed.parsed
+    })
 
     return envVarsArray.reduce((acc, curr) => ({ ...acc, ...curr }), {})
   }

--- a/test/index.js
+++ b/test/index.js
@@ -397,5 +397,95 @@ describe('ServerlessPlugin', function () {
         env2: envVars.env2,
       })
     })
+
+    it('does not use `dotenv-expand` when `variableExpansion` is set to `false`', function () {
+      const fileName = '.env'
+      const envVars = {
+        env1: 'env1value',
+        env2: 'env2value',
+        env3: 'env3value',
+      }
+
+      const serverless = {
+        cli: {
+          log: this.sandbox.stub(),
+        },
+        service: {
+          custom: {
+            dotenv: {
+              variableExpansion: false,
+            },
+          },
+          provider: {},
+        },
+      }
+
+      const plugin = new this.ServerlessPlugin(serverless, this.options)
+
+      const resolveEnvFileNames = this.sandbox.stub(
+        plugin,
+        'resolveEnvFileNames',
+      )
+
+      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns({ parsed: envVars })
+
+      plugin.loadEnv(this.env)
+
+      serverless.service.provider.environment.should.deep.equal({
+        env1: envVars.env1,
+        env2: envVars.env2,
+        env3: envVars.env3,
+      })
+
+      this.requireStubs['dotenv-expand'].should.not.have.been.called
+    })
+
+    it('runs with defaults when there are no configs', function () {
+      const fileName = '.env'
+      const envVars = {
+        env1: 'env1value',
+        env2: 'env2value',
+        env3: 'env3value',
+      }
+
+      const serverless = {
+        cli: {
+          log: this.sandbox.stub(),
+        },
+        service: {
+          custom: {},
+          provider: {},
+        },
+      }
+
+      const plugin = new this.ServerlessPlugin(serverless, this.options)
+
+      const resolveEnvFileNames = this.sandbox.stub(
+        plugin,
+        'resolveEnvFileNames',
+      )
+
+      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns({ parsed: envVars })
+
+      this.requireStubs['dotenv-expand']
+        .withArgs({ parsed: envVars })
+        .returns({ parsed: envVars })
+
+      plugin.loadEnv(this.env)
+
+      serverless.service.provider.environment.should.deep.equal({
+        env1: envVars.env1,
+        env2: envVars.env2,
+        env3: envVars.env3,
+      })
+    })
   })
 })


### PR DESCRIPTION
## Description

Resolves #90. This pull request adds an option to turn off variable expansion (but leaves it on by default).

## Checklist

<!-- Note: not all checklist items are applicable to all pull requests -->

* [x] CHANGELOG.md
* [x] README.md
* [x] Unit tests
* [x] Consider performance implications
* [x] Consider security implications

## Exploratory Test Notes

Using a `.env` file with the following contents:

```
INNER_ENV=innerenv
OUTER_ENV=hi-$INNER_ENV
```

```yaml
custom:
  dotenv:
    variableExpansion: false
```

results in `{ INNER_ENV: 'innerenv', OUTER_ENV: 'hi-$INNER_ENV' }` as expected.

```yaml
custom:
  dotenv:
    required:
      file: true
```

results in `{ INNER_ENV: 'innerenv', OUTER_ENV: 'hi-innerenv' }` as expected.

No `custom.dotenv` property inside `serverless.yml` results in `{ INNER_ENV: 'innerenv', OUTER_ENV: 'hi-innerenv' }` as expected.