### PR TITLE
feat: new option to expect specific env vars to be set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,27 @@
 # Changelog
 
-Changes not included in this log but can be reviewed on GitHub:
+Only major and minor version changes are included in this file. Changes not
+included in this log but can be reviewed on GitHub:
 
 * ["Chore"](https://github.com/neverendingqs/serverless-dotenv-plugin/pulls?q=+is%3Apr+label%3Achore+)
 * [Documentation](https://github.com/neverendingqs/serverless-dotenv-plugin/pulls?q=+is%3Apr+label%3Adocumentation)
 
 ## Unreleased
 
-## 3.3.0
+## 3.3.x
+
+* feat: new option to expect specific env vars to be set. ([#118](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/118))
+
+## 3.3.x
 
 * feat: adding variableExpansion option to turn off variable expansion. ([#116](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/116))
 
-## 3.2.0
+## 3.2.x
 
 * refactor: use helper functions to help with readabilty and future changes. ([#112](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/112))
 * Significant changes to documentation structure ([#85..#108 labelled `documentation`](https://github.com/neverendingqs/serverless-dotenv-plugin/pulls?q=is%3Apr+label%3Adocumentation+closed%3A2021-02-06..2021-02-07+))
 
-## 3.0.0
+## 3.0.x
 
 * feat: Load `.env.*.local` envs ([#55](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/55)) ([@danilofuchs](https://github.com/danilofuchs))
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ custom:
 
     # default: plugin does not cause an error if any file or env variable is missing
     required:
+      # default: []
+      env:
+        - API_KEY
+
       # default: false
       file: true
 
@@ -137,9 +141,14 @@ custom:
 * logging: true|false
   * Supresses all logging done by this plugin if no errors are encountered.
 
-* required.file: true|false (default false)
-  * By default, this plugin will exit gracefully and allow Serverless to continue even if it couldn't find a .env file to use.
-  * Set this to `true` to cause Serverless to halt if it could not find a .env file to use.
+* required
+  * env: (list)
+    * A set of env var that must be set either in the Serverless environment or via a `dotenv` file.
+    * Throws an error if a required env var is not found.
+    * By default, no env vars are required.
+  * file: true|false (default false)
+    * By default, this plugin will exit gracefully and allow Serverless to continue even if it couldn't find a .env file to use.
+    * Set this to `true` to cause Serverless to halt if it could not find a .env file to use.
 
 * variableExpansion: true|false (default true)
   * By default, variables can reference other variables

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ class ServerlessPlugin {
     )
 
     const missingRequiredEnvVars = (this.required.env || []).filter(
-      (envVarName) => !envVars[envVarName],
+      (envVarName) => !envVars[envVarName] && !process.env[envVarName],
     )
 
     if (missingRequiredEnvVars.length > 0) {

--- a/index.js
+++ b/index.js
@@ -85,7 +85,27 @@ class ServerlessPlugin {
         : parsed.parsed
     })
 
-    return envVarsArray.reduce((acc, curr) => ({ ...acc, ...curr }), {})
+    const envVars = envVarsArray.reduce(
+      (acc, curr) => ({ ...acc, ...curr }),
+      {},
+    )
+
+    const missingRequiredEnvVars = (this.required.env || []).filter(
+      (envVarName) => !envVars[envVarName],
+    )
+
+    if (missingRequiredEnvVars.length > 0) {
+      throw Object.assign(
+        new Error(
+          `Missing the following required environment variables: ${missingRequiredEnvVars.join(
+            ',',
+          )}`,
+        ),
+        { type: errorTypes.HALT },
+      )
+    }
+
+    return envVars
   }
 
   /**

--- a/test/index.js
+++ b/test/index.js
@@ -282,6 +282,40 @@ describe('ServerlessPlugin', function () {
       should.Throw(() => this.plugin.loadEnv(this.env))
     })
 
+    it('throws an error if a missing env is not set', function () {
+      this.serverless.service.custom.dotenv.required.env = [
+        'NOT_IN_ANY_FILE',
+        'NOT_IN_ANY_FILE2',
+      ]
+
+      const filesAndEnvVars = {
+        file1: {
+          ENV1: 'env1value',
+          ENV2: 'env2overwrittenvalue',
+        },
+        file2: {
+          ENV2: 'env2value',
+          ENV3: 'env3value',
+        },
+      }
+
+      const files = Object.keys(filesAndEnvVars)
+
+      this.resolveEnvFileNames.withArgs(this.env).returns(files)
+
+      files.forEach((fileName) => {
+        this.requireStubs.dotenv.config
+          .withArgs({ path: fileName })
+          .returns({ parsed: filesAndEnvVars[fileName] })
+
+        this.requireStubs['dotenv-expand']
+          .withArgs({ parsed: filesAndEnvVars[fileName] })
+          .returns({ parsed: filesAndEnvVars[fileName] })
+      })
+
+      should.Throw(() => this.plugin.loadEnv(this.env))
+    })
+
     it('loads variables from all files', function () {
       const filesAndEnvVars = {
         file1: {
@@ -293,6 +327,8 @@ describe('ServerlessPlugin', function () {
           env3: 'env3value',
         },
       }
+
+      this.serverless.service.custom.dotenv.required.env = ['env3']
 
       const files = Object.keys(filesAndEnvVars)
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+process.env.TEST_SLS_DOTENV_PLUGIN_ENV1 = 'env1'
+
 const chai = require('chai')
 const proxyquire = require('proxyquire')
 const should = chai.should()
@@ -328,7 +330,10 @@ describe('ServerlessPlugin', function () {
         },
       }
 
-      this.serverless.service.custom.dotenv.required.env = ['env3']
+      this.serverless.service.custom.dotenv.required.env = [
+        'env3',
+        'TEST_SLS_DOTENV_PLUGIN_ENV1',
+      ]
 
       const files = Object.keys(filesAndEnvVars)
 


### PR DESCRIPTION
## Description

Resolves #20. Note: we allow env vars to be set outside of this plugin, as env vars containing secrets are likely declared elsewhere (e.g. CI / CD system).

## Checklist

<!-- Note: not all checklist items are applicable to all pull requests -->

* [x] CHANGELOG.md
* [x] README.md
* [x] Unit tests
* [x] Consider performance implications
* [x] Consider security implications

## Exploratory Test Notes

* Confirmed plugin ran without issues if env var is set as expected
* Confirmed plugin threw an error when an expected env var is not set as expected
* Confirmed plugin ran without issues if env var is set, but not by this plugin as expected
