### PR TITLE
fix: warning about include and exclude now only warns in that specific case.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ class ServerlessPlugin {
     const exclude = (this.config && this.config.exclude) || []
 
     if (include.length > 0) {
-      if (exclude) {
+      if (exclude.length > 0) {
         this.log('DOTENV (WARNING): if "include" is set, "exclude" is ignored.')
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -455,6 +455,10 @@ describe('ServerlessPlugin', function () {
       this.serverless.service.provider.environment.should.deep.equal({
         env2: envVars.env2,
       })
+
+      this.serverless.cli.log.should.have.not.been.calledWith(
+        sinon.match(/exclude/),
+      )
     })
 
     it('removes keys in config.exclude', function () {


### PR DESCRIPTION
## Description

Before, the warning will always show up even if `exclude` is empty.

## Checklist

<!-- Note: not all checklist items are applicable to all pull requests -->

* [x] CHANGELOG.md (N/A - will be a patch version)
* [x] README.md
* [x] Unit tests
* [x] Consider performance implications
* [x] Consider security implications

## Exploratory Test Notes
* TDD'ed
