### PR TITLE
refactor: semicolons are now required.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "trailingComma": "all"
 }

--- a/examples/simple-express-app/index.js
+++ b/examples/simple-express-app/index.js
@@ -1,9 +1,9 @@
-const serverless = require('serverless-http')
-const express = require('express')
-const app = express()
+const serverless = require('serverless-http');
+const express = require('express');
+const app = express();
 
 app.get('/', function (req, res) {
-  res.send(`Hello ${process.env.APP_MESSAGE}!`)
-})
+  res.send(`Hello ${process.env.APP_MESSAGE}!`);
+});
 
-module.exports.handler = serverless(app)
+module.exports.handler = serverless(app);

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,20 @@
-'use strict'
+'use strict';
 
-const dotenv = require('dotenv')
-const dotenvExpand = require('dotenv-expand')
-const chalk = require('chalk')
-const fs = require('fs')
-const path = require('path')
+const dotenv = require('dotenv');
+const dotenvExpand = require('dotenv-expand');
+const chalk = require('chalk');
+const fs = require('fs');
+const path = require('path');
 
 const errorTypes = {
   HALT: 'HALT',
-}
+};
 
 class ServerlessPlugin {
   constructor(serverless, options) {
-    this.serverless = serverless
+    this.serverless = serverless;
     this.serverless.service.provider.environment =
-      this.serverless.service.provider.environment || {}
+      this.serverless.service.provider.environment || {};
 
     this.config = Object.assign(
       {
@@ -26,21 +26,21 @@ class ServerlessPlugin {
       (this.serverless.service.custom &&
         this.serverless.service.custom['dotenv']) ||
         {},
-    )
+    );
 
     if (this.config.dotenvParser) {
       this.config.dotenvParserPath = path.join(
         serverless.config.servicePath,
         this.config.dotenvParser,
-      )
+      );
     }
 
-    this.loadEnv(this.getEnvironment(options))
+    this.loadEnv(this.getEnvironment(options));
   }
 
   log(...args) {
     if (this.config.logging) {
-      this.serverless.cli.log(...args)
+      this.serverless.cli.log(...args);
     }
   }
 
@@ -49,7 +49,9 @@ class ServerlessPlugin {
    * @returns {string}
    */
   getEnvironment(options) {
-    return process.env.NODE_ENV || options.env || options.stage || 'development'
+    return (
+      process.env.NODE_ENV || options.env || options.stage || 'development'
+    );
   }
 
   /**
@@ -57,17 +59,17 @@ class ServerlessPlugin {
    * @returns {string[]}
    */
   resolveEnvFileNames(env) {
-    const basePath = (this.config && this.config.basePath) || ''
+    const basePath = (this.config && this.config.basePath) || '';
 
     if (this.config && this.config.path) {
       if (basePath) {
-        this.log('DOTENV (WARNING): if "path" is set, "basePath" is ignored.')
+        this.log('DOTENV (WARNING): if "path" is set, "basePath" is ignored.');
       }
 
       if (Array.isArray(this.config.path)) {
-        return this.config.path
+        return this.config.path;
       }
-      return [this.config.path]
+      return [this.config.path];
     }
 
     // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
@@ -79,11 +81,11 @@ class ServerlessPlugin {
       // results for everyone
       env !== 'test' && `.env.local`,
       `.env`,
-    ]
+    ];
 
-    const filesNames = dotenvFiles.map((file) => basePath + file)
+    const filesNames = dotenvFiles.map((file) => basePath + file);
 
-    return filesNames.filter((fileName) => fs.existsSync(fileName))
+    return filesNames.filter((fileName) => fs.existsSync(fileName));
   }
 
   /**
@@ -95,9 +97,9 @@ class ServerlessPlugin {
       return require(this.config.dotenvParserPath)({
         dotenv,
         paths: envFileNames,
-      })
+      });
     } catch (err) {
-      throw Object.assign(err, { type: errorTypes.HALT })
+      throw Object.assign(err, { type: errorTypes.HALT });
     }
   }
 
@@ -107,44 +109,46 @@ class ServerlessPlugin {
    */
   parseEnvFiles(envFileNames) {
     const envVarsArray = envFileNames.map((fileName) => {
-      const parsed = dotenv.config({ path: fileName })
+      const parsed = dotenv.config({ path: fileName });
       return this.config.variableExpansion
         ? dotenvExpand(parsed).parsed
-        : parsed.parsed
-    })
+        : parsed.parsed;
+    });
 
-    return envVarsArray.reduce((acc, curr) => ({ ...acc, ...curr }), {})
+    return envVarsArray.reduce((acc, curr) => ({ ...acc, ...curr }), {});
   }
 
   /**
    * @param {Object} envVars
    */
   setProviderEnv(envVars) {
-    const include = (this.config && this.config.include) || []
-    const exclude = (this.config && this.config.exclude) || []
+    const include = (this.config && this.config.include) || [];
+    const exclude = (this.config && this.config.exclude) || [];
 
     if (include.length > 0) {
       if (exclude.length > 0) {
-        this.log('DOTENV (WARNING): if "include" is set, "exclude" is ignored.')
+        this.log(
+          'DOTENV (WARNING): if "include" is set, "exclude" is ignored.',
+        );
       }
 
       Object.keys(envVars)
         .filter((key) => !include.includes(key))
         .forEach((key) => {
-          delete envVars[key]
-        })
+          delete envVars[key];
+        });
     } else if (exclude.length > 0) {
       Object.keys(envVars)
         .filter((key) => exclude.includes(key))
         .forEach((key) => {
-          delete envVars[key]
-        })
+          delete envVars[key];
+        });
     }
 
     Object.keys(envVars).forEach((key) => {
-      this.log('\t - ' + key)
-      this.serverless.service.provider.environment[key] = envVars[key]
-    })
+      this.log('\t - ' + key);
+      this.serverless.service.provider.environment[key] = envVars[key];
+    });
   }
 
   /**
@@ -156,13 +160,13 @@ class ServerlessPlugin {
         'DOTENV: Loading environment variables from ' +
           [...envFileNames].reverse().join(', ') +
           ':',
-      )
+      );
     } else {
-      const errorMsg = 'DOTENV: Could not find .env file.'
-      this.log(errorMsg)
+      const errorMsg = 'DOTENV: Could not find .env file.';
+      this.log(errorMsg);
 
       if (this.config.required.file === true) {
-        throw Object.assign(new Error(errorMsg), { type: errorTypes.HALT })
+        throw Object.assign(new Error(errorMsg), { type: errorTypes.HALT });
       }
     }
   }
@@ -177,12 +181,12 @@ class ServerlessPlugin {
           'Unexpected env var object (expected an object but is falsy). Did you forget to return an object in your dotenv parser?',
         ),
         { type: errorTypes.HALT },
-      )
+      );
     }
 
     const missingRequiredEnvVars = (this.config.required.env || []).filter(
       (envVarName) => !envVars[envVarName] && !process.env[envVarName],
-    )
+    );
 
     if (missingRequiredEnvVars.length > 0) {
       throw Object.assign(
@@ -192,7 +196,7 @@ class ServerlessPlugin {
           )}`,
         ),
         { type: errorTypes.HALT },
-      )
+      );
     }
   }
 
@@ -200,29 +204,29 @@ class ServerlessPlugin {
    * @param {string} env
    */
   loadEnv(env) {
-    const envFileNames = this.resolveEnvFileNames(env)
+    const envFileNames = this.resolveEnvFileNames(env);
     try {
-      this.validateEnvFileNames(envFileNames)
+      this.validateEnvFileNames(envFileNames);
 
       const envVars = this.config.dotenvParserPath
         ? this.callDotenvParser(envFileNames)
-        : this.parseEnvFiles(envFileNames)
+        : this.parseEnvFiles(envFileNames);
 
-      this.validateEnvVars(envVars)
-      this.setProviderEnv(envVars)
+      this.validateEnvVars(envVars);
+      this.setProviderEnv(envVars);
     } catch (e) {
       if (e.type === errorTypes.HALT) {
-        throw e
+        throw e;
       }
 
       console.error(
         chalk.red(
           '\n Serverless Plugin Error --------------------------------------\n',
         ),
-      )
-      console.error(chalk.red('  ' + e.message))
+      );
+      console.error(chalk.red('  ' + e.message));
     }
   }
 }
 
-module.exports = ServerlessPlugin
+module.exports = ServerlessPlugin;

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,26 @@
-process.env.TEST_SLS_DOTENV_PLUGIN_ENV1 = 'env1'
+process.env.TEST_SLS_DOTENV_PLUGIN_ENV1 = 'env1';
 
-const chai = require('chai')
-const path = require('path')
-const proxyquire = require('proxyquire').noCallThru()
-const should = chai.should()
-const sinon = require('sinon')
+const chai = require('chai');
+const path = require('path');
+const proxyquire = require('proxyquire').noCallThru();
+const should = chai.should();
+const sinon = require('sinon');
 
-chai.use(require('sinon-chai'))
+chai.use(require('sinon-chai'));
 
 describe('ServerlessPlugin', function () {
   beforeEach(function () {
-    this.sandbox = sinon.createSandbox()
+    this.sandbox = sinon.createSandbox();
 
     this.dotenvParser = {
       path: 'dotenvParser.js',
       prefix: '/tmp',
-    }
+    };
 
     this.dotenvParser.fullPath = path.join(
       this.dotenvParser.prefix,
       this.dotenvParser.path,
-    )
+    );
 
     this.requireStubs = {
       chalk: {
@@ -34,9 +34,9 @@ describe('ServerlessPlugin', function () {
         existsSync: this.sandbox.stub(),
       },
       [this.dotenvParser.fullPath]: this.sandbox.stub(),
-    }
+    };
 
-    this.ServerlessPlugin = proxyquire('../src', this.requireStubs)
+    this.ServerlessPlugin = proxyquire('../src', this.requireStubs);
 
     this.serverless = {
       cli: {
@@ -45,280 +45,290 @@ describe('ServerlessPlugin', function () {
       service: {
         provider: {},
       },
-    }
-    this.options = {}
+    };
+    this.options = {};
 
     this.createPlugin = () =>
-      new this.ServerlessPlugin(this.serverless, this.options)
-  })
+      new this.ServerlessPlugin(this.serverless, this.options);
+  });
 
   afterEach(function () {
-    this.sandbox.verifyAndRestore()
-  })
+    this.sandbox.verifyAndRestore();
+  });
 
   describe('constructor()', function () {
     it('does not err out on minimal configuration', function () {
-      should.exist(this.createPlugin())
-    })
+      should.exist(this.createPlugin());
+    });
 
     it('loads environment variables as expected', function () {
-      const env = 'unittests'
+      const env = 'unittests';
 
       const getEnvironment = this.sandbox.stub(
         this.ServerlessPlugin.prototype,
         'getEnvironment',
-      )
-      getEnvironment.withArgs(this.options).returns(env)
+      );
+      getEnvironment.withArgs(this.options).returns(env);
 
       const loadEnv = this.sandbox.stub(
         this.ServerlessPlugin.prototype,
         'loadEnv',
-      )
+      );
 
-      this.createPlugin()
+      this.createPlugin();
 
-      loadEnv.should.have.been.calledWith(env)
-    })
-  })
+      loadEnv.should.have.been.calledWith(env);
+    });
+  });
 
   describe('log()', function () {
     it('logs by default', function () {
-      const msg = 'msg'
-      this.createPlugin().log(msg)
-      this.serverless.cli.log.should.be.calledWith(msg)
-    })
+      const msg = 'msg';
+      this.createPlugin().log(msg);
+      this.serverless.cli.log.should.be.calledWith(msg);
+    });
 
     it('does nothing if logging is disabled', function () {
       this.serverless.service.custom = {
         dotenv: {
           logging: false,
         },
-      }
+      };
 
-      this.createPlugin().log('msg')
+      this.createPlugin().log('msg');
 
-      this.serverless.cli.log.should.not.be.called
-    })
-  })
+      this.serverless.cli.log.should.not.be.called;
+    });
+  });
 
   describe('getEnvironment()', function () {
     it("set to 'development' when no other options are available", function () {
-      this.createPlugin().getEnvironment({}).should.equal('development')
-    })
+      this.createPlugin().getEnvironment({}).should.equal('development');
+    });
 
     it('uses option.stage if it is set', function () {
       this.createPlugin()
         .getEnvironment({ stage: 'teststage' })
-        .should.equal('teststage')
-    })
+        .should.equal('teststage');
+    });
 
     it('prefers option.env if it is set', function () {
       this.createPlugin()
         .getEnvironment({ env: 'testenv', stage: 'teststage' })
-        .should.equal('testenv')
-    })
+        .should.equal('testenv');
+    });
 
     it('prefers NODE_ENV if it is set', function () {
-      this.sandbox.stub(process, 'env').value({ NODE_ENV: 'TEST_NODE_ENV' })
+      this.sandbox.stub(process, 'env').value({ NODE_ENV: 'TEST_NODE_ENV' });
       this.createPlugin()
         .getEnvironment({ env: 'theenv', stage: 'thestage' })
-        .should.equal('TEST_NODE_ENV')
-    })
-  })
+        .should.equal('TEST_NODE_ENV');
+    });
+  });
 
   describe('resolveEnvFileNames()', function () {
     describe('with config.path configured', function () {
       it('returns singleton array if set to a string value', function () {
-        const path = '.env.unittest'
+        const path = '.env.unittest';
         this.serverless.service.custom = {
           dotenv: { path },
-        }
+        };
 
-        this.createPlugin().resolveEnvFileNames('env').should.deep.equal([path])
-      })
+        this.createPlugin()
+          .resolveEnvFileNames('env')
+          .should.deep.equal([path]);
+      });
 
       it('returns config.path as-is if set to an array value', function () {
-        const path = ['.env.unittest0', '.env.unittest1']
+        const path = ['.env.unittest0', '.env.unittest1'];
         this.serverless.service.custom = {
           dotenv: { path },
-        }
+        };
 
-        this.createPlugin().resolveEnvFileNames('env').should.deep.equal(path)
-      })
+        this.createPlugin().resolveEnvFileNames('env').should.deep.equal(path);
+      });
 
       it('logs an error if basePath is also set', function () {
-        const path = '.env.unittest'
+        const path = '.env.unittest';
         this.serverless.service.custom = {
           dotenv: {
             basePath: 'base/path/',
             path,
           },
-        }
+        };
 
-        this.createPlugin().resolveEnvFileNames('env').should.deep.equal([path])
+        this.createPlugin()
+          .resolveEnvFileNames('env')
+          .should.deep.equal([path]);
         this.serverless.cli.log.should.have.been.calledWith(
           sinon.match(/basePath/),
-        )
-      })
-    })
+        );
+      });
+    });
 
     describe('with default dotenv paths', function () {
-      ;['staging', 'production', 'dmz'].forEach((env) => {
+      ['staging', 'production', 'dmz'].forEach((env) => {
         it(`returns all path with any "env" other than "test" (${env})`, function () {
           const expectedDotenvFiles = [
             `.env.${env}.local`,
             `.env.${env}`,
             '.env.local',
             '.env',
-          ]
+          ];
 
           expectedDotenvFiles.forEach((file) =>
             this.requireStubs.fs.existsSync.withArgs(file).returns(true),
-          )
+          );
 
           this.createPlugin()
             .resolveEnvFileNames(env)
-            .should.deep.equal(expectedDotenvFiles)
-        })
+            .should.deep.equal(expectedDotenvFiles);
+        });
 
         it('filters out files that do not exist', function () {
-          const missingDotEnvFiles = [`.env.${env}`, '.env.local']
+          const missingDotEnvFiles = [`.env.${env}`, '.env.local'];
 
-          const expectedDotenvFiles = [`.env.${env}.local`, '.env']
+          const expectedDotenvFiles = [`.env.${env}.local`, '.env'];
 
           missingDotEnvFiles.forEach((file) =>
             this.requireStubs.fs.existsSync.withArgs(file).returns(false),
-          )
+          );
 
           expectedDotenvFiles.forEach((file) =>
             this.requireStubs.fs.existsSync.withArgs(file).returns(true),
-          )
+          );
 
           this.createPlugin()
             .resolveEnvFileNames(env)
-            .should.deep.equal(expectedDotenvFiles)
-        })
-      })
+            .should.deep.equal(expectedDotenvFiles);
+        });
+      });
 
       it('excludes local env file if "env" is set to "test"', function () {
-        const env = 'test'
-        const expectedDotenvFiles = [`.env.${env}.local`, `.env.${env}`, '.env']
+        const env = 'test';
+        const expectedDotenvFiles = [
+          `.env.${env}.local`,
+          `.env.${env}`,
+          '.env',
+        ];
 
         expectedDotenvFiles.forEach((file) =>
           this.requireStubs.fs.existsSync.withArgs(file).returns(true),
-        )
+        );
 
         this.createPlugin()
           .resolveEnvFileNames(env)
-          .should.deep.equal(expectedDotenvFiles)
-      })
+          .should.deep.equal(expectedDotenvFiles);
+      });
 
       it('uses "basePath" config if set', function () {
-        const basePath = 'unittest/'
+        const basePath = 'unittest/';
         this.serverless.service.custom = {
           dotenv: { basePath },
-        }
+        };
 
-        const env = 'unittest'
+        const env = 'unittest';
         const expectedDotenvFiles = [
           `${basePath}.env.${env}.local`,
           `${basePath}.env.${env}`,
           `${basePath}.env.local`,
           `${basePath}.env`,
-        ]
+        ];
 
         expectedDotenvFiles.forEach((file) =>
           this.requireStubs.fs.existsSync.withArgs(file).returns(true),
-        )
+        );
 
         this.createPlugin()
           .resolveEnvFileNames(env)
-          .should.deep.equal(expectedDotenvFiles)
-      })
-    })
-  })
+          .should.deep.equal(expectedDotenvFiles);
+      });
+    });
+  });
 
   describe('loadEnv()', function () {
     beforeEach(function () {
-      this.env = 'unittests'
+      this.env = 'unittests';
 
       this.setupResolveEnvFileNames = () => {
         const getEnvironment = this.sandbox.stub(
           this.ServerlessPlugin.prototype,
           'getEnvironment',
-        )
-        getEnvironment.withArgs(this.options).returns(this.env)
+        );
+        getEnvironment.withArgs(this.options).returns(this.env);
 
         const resolveEnvFileNames = this.sandbox.stub(
           this.ServerlessPlugin.prototype,
           'resolveEnvFileNames',
-        )
+        );
 
-        return resolveEnvFileNames
-      }
-    })
+        return resolveEnvFileNames;
+      };
+    });
 
     it('throws an error if resolveEnvFileNames() throws an error', function () {
-      const error = new Error('Error in resolveEnvFileNames()')
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).throws(error)
+      const error = new Error('Error in resolveEnvFileNames()');
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).throws(error);
 
-      should.Throw(() => this.createPlugin(), error)
-    })
+      should.Throw(() => this.createPlugin(), error);
+    });
 
     it('logs an error if dotenv.config() throws an error', function () {
-      const fileName = '.env'
+      const fileName = '.env';
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
-      const error = new Error('Error while calling dotenv.config()')
-      this.requireStubs.dotenv.config.withArgs({ path: fileName }).throws(error)
-
-      this.createPlugin()
-
-      this.requireStubs.chalk.red.should.have.been.calledWith(
-        '  ' + error.message,
-      )
-    })
-
-    it('logs an error if dotenvExpand() throws an error', function () {
-      const fileName = '.env'
-
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
-
-      const dotenvConfigResponse = {}
+      const error = new Error('Error while calling dotenv.config()');
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns(dotenvConfigResponse)
+        .throws(error);
 
-      const error = new Error('Error while calling dotenvExpand()')
-      this.requireStubs['dotenv-expand']
-        .withArgs(dotenvConfigResponse)
-        .throws(error)
-
-      this.createPlugin()
+      this.createPlugin();
 
       this.requireStubs.chalk.red.should.have.been.calledWith(
         '  ' + error.message,
-      )
-    })
+      );
+    });
+
+    it('logs an error if dotenvExpand() throws an error', function () {
+      const fileName = '.env';
+
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
+
+      const dotenvConfigResponse = {};
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns(dotenvConfigResponse);
+
+      const error = new Error('Error while calling dotenvExpand()');
+      this.requireStubs['dotenv-expand']
+        .withArgs(dotenvConfigResponse)
+        .throws(error);
+
+      this.createPlugin();
+
+      this.requireStubs.chalk.red.should.have.been.calledWith(
+        '  ' + error.message,
+      );
+    });
 
     it('logs an error if no .env files are required and none are found', function () {
-      const log = this.sandbox.stub(this.ServerlessPlugin.prototype, 'log')
+      const log = this.sandbox.stub(this.ServerlessPlugin.prototype, 'log');
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([]);
 
-      this.createPlugin()
+      this.createPlugin();
 
-      log.should.have.been.calledWith('DOTENV: Could not find .env file.')
-    })
+      log.should.have.been.calledWith('DOTENV: Could not find .env file.');
+    });
 
     it('throws an error if no .env files are found but at least one is required', function () {
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([]);
 
       this.serverless.service.custom = {
         dotenv: {
@@ -326,10 +336,10 @@ describe('ServerlessPlugin', function () {
             file: true,
           },
         },
-      }
+      };
 
-      should.Throw(() => this.createPlugin())
-    })
+      should.Throw(() => this.createPlugin());
+    });
 
     it('throws an error if a missing env is not set', function () {
       const filesAndEnvVars = {
@@ -341,22 +351,22 @@ describe('ServerlessPlugin', function () {
           ENV2: 'env2value',
           ENV3: 'env3value',
         },
-      }
+      };
 
-      const files = Object.keys(filesAndEnvVars)
+      const files = Object.keys(filesAndEnvVars);
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns(files)
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns(files);
 
       files.forEach((fileName) => {
         this.requireStubs.dotenv.config
           .withArgs({ path: fileName })
-          .returns({ parsed: filesAndEnvVars[fileName] })
+          .returns({ parsed: filesAndEnvVars[fileName] });
 
         this.requireStubs['dotenv-expand']
           .withArgs({ parsed: filesAndEnvVars[fileName] })
-          .returns({ parsed: filesAndEnvVars[fileName] })
-      })
+          .returns({ parsed: filesAndEnvVars[fileName] });
+      });
 
       this.serverless.service.custom = {
         dotenv: {
@@ -364,10 +374,10 @@ describe('ServerlessPlugin', function () {
             env: ['NOT_IN_ANY_FILE', 'NOT_IN_ANY_FILE2'],
           },
         },
-      }
+      };
 
-      should.Throw(() => this.createPlugin())
-    })
+      should.Throw(() => this.createPlugin());
+    });
 
     it('loads variables from all files', function () {
       const filesAndEnvVars = {
@@ -379,7 +389,7 @@ describe('ServerlessPlugin', function () {
           env2: 'env2value',
           env3: 'env3value',
         },
-      }
+      };
 
       this.serverless.service.custom = {
         dotenv: {
@@ -387,256 +397,256 @@ describe('ServerlessPlugin', function () {
             env: ['env3', 'TEST_SLS_DOTENV_PLUGIN_ENV1'],
           },
         },
-      }
+      };
 
-      const files = Object.keys(filesAndEnvVars)
+      const files = Object.keys(filesAndEnvVars);
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns(files)
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns(files);
 
       files.forEach((fileName) => {
         this.requireStubs.dotenv.config
           .withArgs({ path: fileName })
-          .returns({ parsed: filesAndEnvVars[fileName] })
+          .returns({ parsed: filesAndEnvVars[fileName] });
 
         this.requireStubs['dotenv-expand']
           .withArgs({ parsed: filesAndEnvVars[fileName] })
-          .returns({ parsed: filesAndEnvVars[fileName] })
-      })
+          .returns({ parsed: filesAndEnvVars[fileName] });
+      });
 
-      this.createPlugin()
+      this.createPlugin();
 
       const expectedEnvVars = Object.values(filesAndEnvVars).reduce(
         (acc, envVars) => Object.assign(acc, envVars),
         {},
-      )
+      );
 
       this.serverless.service.provider.environment.should.deep.equal(
         expectedEnvVars,
-      )
-    })
+      );
+    });
 
     it('removes keys not in config.include', function () {
-      const fileName = '.env'
+      const fileName = '.env';
       const envVars = {
         env1: 'env1value',
         env2: 'env2value',
         env3: 'env3value',
-      }
+      };
 
       this.serverless.service.custom = {
         dotenv: {
           include: ['env2'],
         },
-      }
+      };
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
       this.requireStubs['dotenv-expand']
         .withArgs({ parsed: envVars })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
-      this.createPlugin()
+      this.createPlugin();
 
       this.serverless.service.provider.environment.should.deep.equal({
         env2: envVars.env2,
-      })
+      });
 
       this.serverless.cli.log.should.have.not.been.calledWith(
         sinon.match(/exclude/),
-      )
-    })
+      );
+    });
 
     it('removes keys in config.exclude', function () {
-      const fileName = '.env'
+      const fileName = '.env';
       const envVars = {
         env1: 'env1value',
         env2: 'env2value',
         env3: 'env3value',
-      }
+      };
       this.serverless.service.custom = {
         dotenv: {
           exclude: ['env2'],
         },
-      }
+      };
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
       this.requireStubs['dotenv-expand']
         .withArgs({ parsed: envVars })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
-      this.createPlugin()
+      this.createPlugin();
 
       this.serverless.service.provider.environment.should.deep.equal({
         env1: envVars.env1,
         env3: envVars.env3,
-      })
-    })
+      });
+    });
 
     it('ignores config.exclude if config.include is set', function () {
-      const fileName = '.env'
+      const fileName = '.env';
       const envVars = {
         env1: 'env1value',
         env2: 'env2value',
         env3: 'env3value',
-      }
+      };
 
       this.serverless.service.custom = {
         dotenv: {
           include: ['env1', 'env2'],
           exclude: ['env2'],
         },
-      }
+      };
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
       this.requireStubs['dotenv-expand']
         .withArgs({ parsed: envVars })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
-      this.createPlugin()
+      this.createPlugin();
 
       this.serverless.service.provider.environment.should.deep.equal({
         env1: envVars.env1,
         env2: envVars.env2,
-      })
+      });
 
       this.serverless.cli.log.should.have.been.calledWith(
         sinon.match(/exclude/),
-      )
-    })
+      );
+    });
 
     it('does not use `dotenv-expand` when `variableExpansion` is set to `false`', function () {
-      const fileName = '.env'
+      const fileName = '.env';
       const envVars = {
         env1: 'env1value',
         env2: 'env2value',
         env3: 'env3value',
-      }
+      };
 
       this.serverless.service.custom = {
         dotenv: {
           variableExpansion: false,
         },
-      }
+      };
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
-      this.createPlugin()
+      this.createPlugin();
 
       this.serverless.service.provider.environment.should.deep.equal({
         env1: envVars.env1,
         env2: envVars.env2,
         env3: envVars.env3,
-      })
+      });
 
-      this.requireStubs['dotenv-expand'].should.not.have.been.called
-    })
+      this.requireStubs['dotenv-expand'].should.not.have.been.called;
+    });
 
     describe('dotenvParser', function () {
       beforeEach(function () {
         this.serverless.config = {
           servicePath: this.dotenvParser.prefix,
-        }
+        };
 
         this.serverless.service.custom = {
           dotenv: {
             dotenvParser: this.dotenvParser.path,
           },
-        }
-      })
+        };
+      });
 
       it('throws if importing custom parser causes an error', function () {
-        const error = new Error()
-        this.requireStubs[this.dotenvParser.fullPath].throws(error)
+        const error = new Error();
+        this.requireStubs[this.dotenvParser.fullPath].throws(error);
 
-        should.Throw(() => this.createPlugin(), error)
-      })
+        should.Throw(() => this.createPlugin(), error);
+      });
 
       it('throws if custom parser returns undefined', function () {
-        should.Throw(() => this.createPlugin())
-      })
+        should.Throw(() => this.createPlugin());
+      });
 
       it('uses output of custom parser', function () {
-        const fileName = '.env'
+        const fileName = '.env';
         const envVars = {
           env1: 'env1value',
           env2: 'env2value',
           env3: 'env3value',
-        }
+        };
 
-        const resolveEnvFileNames = this.setupResolveEnvFileNames()
-        resolveEnvFileNames.withArgs(this.env).returns([fileName])
+        const resolveEnvFileNames = this.setupResolveEnvFileNames();
+        resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
         this.requireStubs[this.dotenvParser.fullPath]
           .withArgs({
             dotenv: this.requireStubs.dotenv,
             paths: [fileName],
           })
-          .returns(envVars)
+          .returns(envVars);
 
-        this.createPlugin()
+        this.createPlugin();
 
         this.serverless.service.provider.environment.should.deep.equal({
           env1: envVars.env1,
           env2: envVars.env2,
           env3: envVars.env3,
-        })
-      })
-    })
+        });
+      });
+    });
 
     it('runs with defaults when there are no configs', function () {
-      const fileName = '.env'
+      const fileName = '.env';
       const envVars = {
         env1: 'env1value',
         env2: 'env2value',
         env3: 'env3value',
-      }
+      };
 
-      const resolveEnvFileNames = this.setupResolveEnvFileNames()
-      resolveEnvFileNames.withArgs(this.env).returns([fileName])
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
 
       this.requireStubs.dotenv.config
         .withArgs({ path: fileName })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
       this.requireStubs['dotenv-expand']
         .withArgs({ parsed: envVars })
-        .returns({ parsed: envVars })
+        .returns({ parsed: envVars });
 
-      const plugin = this.createPlugin()
+      const plugin = this.createPlugin();
 
-      plugin.config.logging.should.be.true
-      plugin.config.required.should.deep.equal({})
-      plugin.config.v4BreakingChanges.should.be.false
-      plugin.config.variableExpansion.should.be.true
+      plugin.config.logging.should.be.true;
+      plugin.config.required.should.deep.equal({});
+      plugin.config.v4BreakingChanges.should.be.false;
+      plugin.config.variableExpansion.should.be.true;
 
       this.serverless.service.provider.environment.should.deep.equal({
         env1: envVars.env1,
         env2: envVars.env2,
         env3: envVars.env3,
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});


### PR DESCRIPTION
Semicolons help with some quirkyness around using `forEach()` in tests. Confirmed tests pass if semicolon changes are only applied to `src/index.js`.