### PR TITLE
fix: undo behaviour around include = [].

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ Breaking changes are introduced when going from version 3.x.x to 4.x.x:
     * This is because your environment variables might not be stored in dotenv files in all environments.
     * Setting `required.file` to `true` will continue to cause the plugin to halt if no dotenv files are found.
 
-## 3.8.x
+## 3.8.1
+
+* fix: undo behaviour around include = []. ([#145](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/145))
+
+## 3.8.0
 
 * feat: adding an option to toggle breaking changes. ([#138](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/138))
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,10 +122,10 @@ class ServerlessPlugin {
    * @param {Object} envVars
    */
   setProviderEnv(envVars) {
-    const include = (this.config && this.config.include) || [];
+    const include = this.config && this.config.include;
     const exclude = (this.config && this.config.exclude) || [];
 
-    if (include.length > 0) {
+    if (include) {
       if (exclude.length > 0) {
         this.log(
           'DOTENV (WARNING): if "include" is set, "exclude" is ignored.',

--- a/test/index.js
+++ b/test/index.js
@@ -444,6 +444,40 @@ describe('ServerlessPlugin', function () {
       );
     });
 
+    it('removes all keys if config.include is set to "[]"', function () {
+      const fileName = '.env';
+      const envVars = {
+        env1: 'env1value',
+        env2: 'env2value',
+        env3: 'env3value',
+      };
+
+      this.serverless.service.custom = {
+        dotenv: {
+          include: [],
+        },
+      };
+
+      const resolveEnvFileNames = this.setupResolveEnvFileNames();
+      resolveEnvFileNames.withArgs(this.env).returns([fileName]);
+
+      this.requireStubs.dotenv.config
+        .withArgs({ path: fileName })
+        .returns({ parsed: envVars });
+
+      this.requireStubs['dotenv-expand']
+        .withArgs({ parsed: envVars })
+        .returns({ parsed: envVars });
+
+      this.createPlugin();
+
+      this.serverless.service.provider.environment.should.deep.equal({});
+
+      this.serverless.cli.log.should.have.not.been.calledWith(
+        sinon.match(/exclude/),
+      );
+    });
+
     it('removes keys not in config.include', function () {
       const fileName = '.env';
       const envVars = {


### PR DESCRIPTION
## Description

When `custom.dotenv.include` is set to `[]`, no env vars should be added to the global environment. However, a mistake was made in https://github.com/neverendingqs/serverless-dotenv-plugin/pull/123, and instead, `[]` includes all env vars.

## Checklist

<!-- Note: not all checklist items are applicable to all pull requests -->

* [x] CHANGELOG.md
* [x] README.md
* [x] Unit tests
* [x] Consider performance implications
* [x] Consider security implications

## Exploratory Test Notes

* Confirmed setting `include` to `[]` before this fix means all env vars are set at a global level, which was not expected.
* Confirmed setting `include` to `[]` after this fix means no env vars are set at a global level as expected.
* Confirmed not setting `include` after this fix means all env vars are set at a global level as expected.