### PR TITLE
chore(package.json): register `serverless` as peer dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Breaking changes are introduced when going from version 3.x.x to 4.x.x:
     * This is because your environment variables might not be stored in dotenv files in all environments.
     * Setting `required.file` to `true` will continue to cause the plugin to halt if no dotenv files are found.
 
+## 3.10.x
+
+* chore(package.json): register `serverless` as peer dependency. ([#159](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/159))
+
 ## 3.9.x
 
 * feat: support "*" for include config. ([#146](https://github.com/neverendingqs/serverless-dotenv-plugin/pull/146))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dotenv-plugin",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "proxyquire": "^2.1.3",
     "sinon": "^9.1.0",
     "sinon-chai": "^3.5.0"
+  },
+  "peerDependencies": {
+    "serverless": "1 || 2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-dotenv-plugin",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "Preload environment variables with dotenv into serverless.",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
It's to ensure only compatible versions or Framework are used together with a plugin, and if mismatch occurs, user is informed with meaningful error message.

_This PR is part of Serverless Framework initiative to [curate most popular plugins](https://github.com/serverless/serverless/issues/9025)_


Note: Before we release v3, we will confirm that plugin is safe to run in that version and will propose a PR that upgrades Framework version in peer dependencies