### PR TITLE
docs(readme): Update the README for latest serverless v2 and upcoming v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,30 @@
 [![Coverage Status](https://coveralls.io/repos/github/neverendingqs/serverless-dotenv-plugin/badge.svg?branch=master)](https://coveralls.io/github/neverendingqs/serverless-dotenv-plugin?branch=master)
 [![npm version](https://img.shields.io/npm/v/serverless-dotenv-plugin.svg?style=flat)](https://www.npmjs.com/package/serverless-dotenv-plugin)
 
-Preload environment variables into serverless. Use this plugin if you have variables stored in a `.env` file that you want loaded into your serverless yaml config. This will allow you to reference them as `${env:VAR_NAME}` inside your config _and_ it will load them into your lambdas.
-
-**`serverless>=3.0.0` introduces changes that significantly impacts this plugin. I would love your feedback about this on the [discussion thread](https://github.com/neverendingqs/serverless-dotenv-plugin/discussions/155). See the discussion thread or the FAQ below for details on the impact of how env vars are loaded with `serverless>=2.26.0` and `serverless>=3.0.0`.**
+Preload environment variables into serverless. Use this plugin if you have variables stored in a `.env` file that you want loaded into your Lambda functions.
 
 ## Do you need this plugin?
 
-Changes in `serverless>=3.0.0` means this plugin can no longer preload environment variables into Serverless. You may want to consider an alternative, such as the one outlined in [`serverless-dotenv-example`](https://github.com/neverendingqs/serverless-dotenv-example).
+Serverless Framework can now natively resolve `${env:xxx}` variables from `.env` files by setting [`useDotenv: true` in the configuration](https://www.serverless.com/framework/docs/environment-variables):
+
+```yaml
+useDotenv: true
+
+provider:
+  environment:
+    FOO: ${env:FOO}
+```
+
+This plugin is still useful if you want to automatically import **all** variables from `.env` into functions:
+
+```yaml
+plugins:
+  - serverless-dotenv-plugin
+
+provider:
+  environment:
+    # With the plugin enabled, all variables in .env are automatically imported
+```
 
 ## Install and Setup
 
@@ -38,18 +55,7 @@ AUTH0_CLIENT_ID=abc12345
 AUTH0_CLIENT_SECRET=12345xyz
 ```
 
-Once loaded, you can now access the vars using the standard method for accessing ENV vars in serverless:
-
-```yaml
-...
-provider:
-  name: aws
-  runtime: nodejs6.10
-  stage: ${env:STAGE}
-  region: ${env:AWS_REGION}
-...
-```
-
+When deploying, all the variables listed in `.env` will automatically be available in the deployed Lambda functions.
 
 ## Automatic ENV File Resolution
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ provider:
     FOO: ${env:FOO}
 ```
 
-This plugin is still useful if you want to automatically import **all** variables from `.env` into functions:
+For more complex situations, you will need to [wire up `dotenv` yourself](https://github.com/neverendingqs/serverless-dotenv-example).
+
+This plugin is only useful if you want to automatically import **all** variables from `.env` into functions:
 
 ```yaml
 plugins:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ AUTH0_CLIENT_ID=abc12345
 AUTH0_CLIENT_SECRET=12345xyz
 ```
 
-When deploying, all the variables listed in `.env` will automatically be available in the deployed Lambda functions.
+When deploying, all the variables listed in `.env` will automatically be available in the deployed functions.
 
 ## Automatic ENV File Resolution
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
 [![Coverage Status](https://coveralls.io/repos/github/neverendingqs/serverless-dotenv-plugin/badge.svg?branch=master)](https://coveralls.io/github/neverendingqs/serverless-dotenv-plugin?branch=master)
 [![npm version](https://img.shields.io/npm/v/serverless-dotenv-plugin.svg?style=flat)](https://www.npmjs.com/package/serverless-dotenv-plugin)
 
-Preload environment variables into serverless. Use this plugin if you have variables stored in a `.env` file that you want loaded into your Lambda functions.
+Preload function environment variables into Serverless. Use this plugin if you have variables stored in a `.env` file that you want loaded into your functions.
+
+This used to also preload environment variables into your `serverless.yml` config, but no longer does with `serverless>=2.26.0.
+See [this discussion thread](https://github.com/neverendingqs/serverless-dotenv-plugin/discussions/155) or the FAQ below for details on the impact of how environment variables are loaded with `serverless>=2.26.0` and `serverless>=3.0.0`.**
 
 ## Do you need this plugin?
 


### PR DESCRIPTION
## Description

As mentioned in the discussion (https://github.com/neverendingqs/serverless-dotenv-plugin/discussions/155#discussioncomment-1347632), Serverless Framework v2 **and** (upcoming) v3 support `.env` for `${env:xxx}` variables via an option in the config.

That makes part of this plugin redundant. Especially since the plugin will no longer be able to load environment variables in the process.

However, this plugin is still useful to automatically inject all `.env` variables into functions.

So here is what we can do/recommend users:

- to use `${env:xxx}` with `.env`, use the native Serverless Framework feature
- to import all `.env` variables into functions, use this plugin

See https://github.com/serverless/serverless/pull/10495

I've updated the README to make this clearer. Let me know if that clarifies everything for v3?
