### PR TITLE
Allow to ignore local environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ custom:
 
     # default: true
     variableExpansion: false
+
+    # default: false, includes env vars from the .env files and overrides them with any env-var set in the local environment
+    # when set to true it uses vars from the .env files only, not exposing your local vars to serverless.
+    envFileOnly: false
 ```
 
 * path (string)
@@ -190,6 +194,28 @@ custom:
     * E.g. `INNER_ENV=innerenv, OUTER_ENV=hi-$INNER_ENV`, would resolve to `INNER_ENV=innerenv, OUTER_ENV=hi-innerenv`
   * Setting this to `false` will disable this feature
     * E.g. `INNER_ENV=innerenv, OUTER_ENV=hi-$INNER_ENV`, would resolve to `INNER_ENV=innerenv, OUTER_ENV=hi-$INNER_ENV`
+
+* envFileOnly: true|false (default false)
+  * By default, local environment variables are included in Serverless and functions
+  * Setting this to `false` will cause local environment variables to *not* be included in the resulting variables.
+  * E.g.,
+
+  ````
+  .env:
+    MY_COLOR=red
+
+
+  # With envFileOnly: false (default)
+    MY_COLOR=green sls deploy
+
+    Lambda MY_COLOR Env var will be green
+
+  # With envFileOnly: true
+    MY_COLOR=green sls deploy
+
+    Lambda MY_COLOR Env var will be red, because only the .env files are used.
+
+  ````
 
 
 Example `dotenvParser` file:

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ class ServerlessPlugin {
         required: {},
         variableExpansion: true,
         v4BreakingChanges: false,
+        envFileOnly: false,
       },
       (this.serverless.service.custom &&
         this.serverless.service.custom['dotenv']) ||
@@ -140,7 +141,10 @@ class ServerlessPlugin {
    */
   parseEnvFiles(envFileNames) {
     const envVarsArray = envFileNames.map((fileName) => {
-      const parsed = dotenv.config({ path: fileName });
+      const parsed = dotenv.config({
+        path: fileName,
+        override: this.config.envFileOnly,
+      });
       return this.config.variableExpansion
         ? dotenvExpand.expand(parsed).parsed
         : parsed.parsed;


### PR DESCRIPTION
## Description

While trying to deploy a Serverless App to AWS I noticed the variables defined in the `.env` file were overwritten by the environment variables configured in my local.

This is common when using Visual Studio Code to develop within a container. Often we set the container environment variables, but we don't want these local environment variables to be pushed to AWS when we run `sls deploy`.

Due to this I propose to add an option to decide if only variables defined in files should be used, or if both local and file vars will be used. 

### Current state

```
(.env)
COLOR=RED
````

Running  `COLOR=GREEN sls deploy` will result in `COLOR=GREEN` in AWS.

However, when setting the option `envFileOnly: true` the behavior changes:

Running  `COLOR=GREEN sls deploy` will result in `COLOR=RED` in AWS, ignoring the local value and prioritizing the variables in `.env` files.

This leverages [the override option](https://github.com/motdotla/dotenv#override) provided by dotenv.





## Checklist

<!-- Note: not all checklist items are applicable to all pull requests -->

* [ ] CHANGELOG.md
* [x] README.md
* [ ] Unit tests
* [ ] Consider performance implications
* [ ] Consider security implications

## Exploratory Test Notes

